### PR TITLE
feat: Factory Permission / Seeder Role, RoleHasPermission

### DIFF
--- a/code/database/factories/PermissionFactory.php
+++ b/code/database/factories/PermissionFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Permission>
+ */
+class PermissionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->sentence()
+        ];
+    }
+}

--- a/code/database/factories/RoleFactory.php
+++ b/code/database/factories/RoleFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Role>
+ */
+class RoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/code/database/seeders/DatabaseSeeder.php
+++ b/code/database/seeders/DatabaseSeeder.php
@@ -22,7 +22,10 @@ class DatabaseSeeder extends Seeder
             SubjectSeeder::class,
             CountrySeeder::class,
             ProvinceSeeder::class,
-            CitySeeder::class
+            CitySeeder::class,
+            PermissionSeeder::class,
+            RoleSeeder::class,
+            RoleHasPermissionSeeder::class
         ]);
     }
 }

--- a/code/database/seeders/PermissionSeeder.php
+++ b/code/database/seeders/PermissionSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Permission;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Permission::factory(10)->create();
+    }
+}

--- a/code/database/seeders/RoleHasPermissionSeeder.php
+++ b/code/database/seeders/RoleHasPermissionSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Seeder;
+
+class RoleHasPermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //Bucle que inserta la cantidad de registros que se quiere
+        for ($i = 1; $i <= 20; $i++) {
+            //Busco la tabla role_has_permissions y le inserto...
+            DB::table('role_has_permissions')->insert([
+                //Role:all busca todos los registros de la tabla Role, random() selecciona uno al azar y id es elcampo que quiero insertar.
+                'role_id' => Role::all()->random()->id,
+                //Permission:all busca todos los registros de la tabla Permission, random() selecciona uno al azar y id es elcampo que quiero insertar.
+                'permission_id' => Permission::all()->random()->id,
+            ]);
+        }
+    }
+}

--- a/code/database/seeders/RoleSeeder.php
+++ b/code/database/seeders/RoleSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class RoleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Role::factory()->create(['name' => 'admin']);
+        Role::factory()->create(['name' => 'principal']);
+        Role::factory()->create(['name' => 'student']);
+        Role::factory()->create(['name' => 'teacher']);
+    }
+}


### PR DESCRIPTION
Se generó una factory con datos falsos en "permissions". Se generó seeders para "roles" con datos predefinidos y para "roles_has_permissions" se generó un código para insertar claves foráneas al azar.